### PR TITLE
Adjust developer setup guide and .env.example

### DIFF
--- a/DEVELOPER_SETUP_GUIDE.md
+++ b/DEVELOPER_SETUP_GUIDE.md
@@ -204,24 +204,24 @@ cd frontend
 # Create environment file
 cat > .env << 'EOF'
 # Enterprise Cognito Configuration
-REACT_APP_USER_POOL_ID=us-east-2_JKsb0fPHX
-REACT_APP_USER_POOL_CLIENT_ID=4qbitb6voa560333ajlg090dh6
-REACT_APP_IDENTITY_POOL_ID=us-east-2:8af4b173-d6f5-4b86-a354-cebc4ccd0d41
-REACT_APP_COGNITO_DOMAIN=https://onefrequency-enterprise-dev.auth.us-east-2.amazoncognito.com
-REACT_APP_AUTH_REDIRECT_URI=https://app.onefrequency.ai/auth/callback
-REACT_APP_AUTH_LOGOUT_URI=https://app.onefrequency.ai/auth/logout
+VITE_USER_POOL_ID=us-east-2_JKsb0fPHX
+VITE_USER_POOL_CLIENT_ID=4qbitb6voa560333ajlg090dh6
+VITE_IDENTITY_POOL_ID=us-east-2:8af4b173-d6f5-4b86-a354-cebc4ccd0d41
+VITE_COGNITO_DOMAIN=https://onefrequency-enterprise-dev.auth.us-east-2.amazoncognito.com
+VITE_AUTH_REDIRECT_URI=https://app.onefrequency.ai/auth/callback
+VITE_AUTH_LOGOUT_URI=https://app.onefrequency.ai/auth/logout
 
 # Enterprise Features
-REACT_APP_ENTERPRISE_MODE=true
-REACT_APP_RBAC_ENABLED=true
+VITE_ENTERPRISE_MODE=true
+VITE_RBAC_ENABLED=true
 
 # Backend API Configuration
-REACT_APP_API_BASE_URL=http://localhost:8080
-REACT_APP_API_VERSION=v1
+VITE_API_BASE_URL=http://localhost:8080
+VITE_API_VERSION=v1
 
 # Development Configuration
-REACT_APP_ENV=development
-REACT_APP_DEBUG=true
+VITE_ENV=development
+VITE_DEBUG=true
 EOF
 ```
 
@@ -507,7 +507,7 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:5173
 
 # Ensure frontend is using correct API URL
 # In frontend/.env:
-REACT_APP_API_BASE_URL=http://localhost:8080
+VITE_API_BASE_URL=http://localhost:8080
 ```
 
 #### 6. Azure Service Connection Issues

--- a/FRONTEND_BACKEND_INTEGRATION_GUIDE.md
+++ b/FRONTEND_BACKEND_INTEGRATION_GUIDE.md
@@ -12,16 +12,16 @@ This guide provides detailed specifications for integrating the new enterprise a
 
 ```bash
 # Enterprise Cognito Configuration
-REACT_APP_USER_POOL_ID=us-east-2_JKsb0fPHX
-REACT_APP_USER_POOL_CLIENT_ID=4qbitb6voa560333ajlg090dh6
-REACT_APP_IDENTITY_POOL_ID=us-east-2:8af4b173-d6f5-4b86-a354-cebc4ccd0d41
-REACT_APP_COGNITO_DOMAIN=https://onefrequency-enterprise-dev.auth.us-east-2.amazoncognito.com
-REACT_APP_AUTH_REDIRECT_URI=https://app.onefrequency.ai/auth/callback
-REACT_APP_AUTH_LOGOUT_URI=https://app.onefrequency.ai/auth/logout
+VITE_USER_POOL_ID=us-east-2_JKsb0fPHX
+VITE_USER_POOL_CLIENT_ID=4qbitb6voa560333ajlg090dh6
+VITE_IDENTITY_POOL_ID=us-east-2:8af4b173-d6f5-4b86-a354-cebc4ccd0d41
+VITE_COGNITO_DOMAIN=https://onefrequency-enterprise-dev.auth.us-east-2.amazoncognito.com
+VITE_AUTH_REDIRECT_URI=https://app.onefrequency.ai/auth/callback
+VITE_AUTH_LOGOUT_URI=https://app.onefrequency.ai/auth/logout
 
 # Enterprise Features
-REACT_APP_ENTERPRISE_MODE=true
-REACT_APP_RBAC_ENABLED=true
+VITE_ENTERPRISE_MODE=true
+VITE_RBAC_ENABLED=true
 ```
 
 **Backend (Go service environment)**

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,19 @@
-VITE_API_URL=your_api_url_here
-VITE_APP_NAME=Music RAG App
+# Enterprise Cognito Configuration
+VITE_USER_POOL_ID=
+VITE_USER_POOL_CLIENT_ID=
+VITE_IDENTITY_POOL_ID=
+VITE_COGNITO_DOMAIN=
+VITE_AUTH_REDIRECT_URI=
+VITE_AUTH_LOGOUT_URI=
+
+# Enterprise Features
+VITE_ENTERPRISE_MODE=true
+VITE_RBAC_ENABLED=true
+
+# Backend API Configuration
+VITE_API_BASE_URL=http://localhost:8080
+VITE_API_VERSION=v1
+
+# Development Configuration
+VITE_ENV=development
+VITE_DEBUG=true


### PR DESCRIPTION
Resolves OFU-23 JIRA story

## Context
The developer setup guide and .env.example were referencing frontend environment variables using the REACT_APP_ prefix. However, the project uses Vite, which requires variables to be prefixed with VITE_ in order to be exposed to the frontend.

## Changes
- adjusted `.env.example` with correct env values
- updated environment variable prefixes from `REACT_APP` to `VITE_` in setup guides